### PR TITLE
[KOGITO-3027] - BOT - Make CI trigger functionailty optional

### DIFF
--- a/src/lib/ci.js
+++ b/src/lib/ci.js
@@ -9,15 +9,19 @@ const { getChangedFiles } = require("./utils");
  */
 async function isCIRequired(context, diff_url) {
   const triggerPaths = await context.config("bot-files/paths.yml");
-  const changedFiles = await getChangedFiles(diff_url);
+  if (triggerPaths !== null) {
+    const changedFiles = await getChangedFiles(diff_url);
 
-  return (
-    triggerPaths.files
-      .map(file => globToRegExp(file))
-      .find(fileExpr =>
-        changedFiles.find(changedFile => fileExpr.test(changedFile))
-      ) !== undefined
-  );
+    return (
+      triggerPaths.files
+        .map(file => globToRegExp(file))
+        .find(fileExpr =>
+          changedFiles.find(changedFile => fileExpr.test(changedFile))
+        ) !== undefined
+    );
+  } else {
+    return false;
+  }
 }
 
 module.exports = {

--- a/src/lib/ci.js
+++ b/src/lib/ci.js
@@ -19,8 +19,6 @@ async function isCIRequired(context, diff_url) {
           changedFiles.find(changedFile => fileExpr.test(changedFile))
         ) !== undefined
     );
-  } else {
-    return false;
   }
 }
 

--- a/src/lib/ci.js
+++ b/src/lib/ci.js
@@ -9,7 +9,7 @@ const { getChangedFiles } = require("./utils");
  */
 async function isCIRequired(context, diff_url) {
   const triggerPaths = await context.config("bot-files/paths.yml");
-  if (triggerPaths !== null) {
+  if (triggerPaths) {
     const changedFiles = await getChangedFiles(diff_url);
 
     return (

--- a/test/ci.test.js
+++ b/test/ci.test.js
@@ -41,3 +41,18 @@ test("is CI required false", async () => {
   // Assert
   expect(!result);
 });
+
+test("isCIRequired paths file not defined", async () => {
+  //Arrange
+  const context = {
+    config: jest.fn(path => (path === "bot-files/paths.yml" ? null : undefined))
+  };
+  const diff_url = "whatever";
+  getChangedFilesMock.mockImplementationOnce(diff =>
+    diff === diff_url ? ["anydir/anyfile"] : undefined
+  );
+  // Act
+  const result = await isCIRequired(context, diff_url);
+  // Assert
+  expect(!result);
+});

--- a/test/ci.test.js
+++ b/test/ci.test.js
@@ -48,9 +48,6 @@ test("isCIRequired paths file not defined", async () => {
     config: jest.fn(() => null)
   };
   const diff_url = "whatever";
-  getChangedFilesMock.mockImplementationOnce(diff =>
-    diff === diff_url ? ["anydir/anyfile"] : undefined
-  );
   // Act
   const result = await isCIRequired(context, diff_url);
   // Assert

--- a/test/ci.test.js
+++ b/test/ci.test.js
@@ -45,7 +45,7 @@ test("is CI required false", async () => {
 test("isCIRequired paths file not defined", async () => {
   //Arrange
   const context = {
-    config: jest.fn(path => (path === "bot-files/paths.yml" ? null : undefined))
+    config: jest.fn(() => null)
   };
   const diff_url = "whatever";
   getChangedFilesMock.mockImplementationOnce(diff =>

--- a/test/ci.test.js
+++ b/test/ci.test.js
@@ -45,7 +45,7 @@ test("is CI required false", async () => {
 test("isCIRequired paths file not defined", async () => {
   //Arrange
   const context = {
-    config: jest.fn(() => null)
+    config: jest.fn(() => undefined)
   };
   const diff_url = "whatever";
   // Act


### PR DESCRIPTION
So if someone doesn't want to have CI trigger functionality, they can choose not to define the paths.yml file
See: https://issues.redhat.com/browse/KOGITO-3027
Signed-off-by: Tarun Khandelwal <tarkhand@redhat.com>